### PR TITLE
Improve video labeler UI and logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit>=1.45
 pandas>=2.3
 streamlit-keyup==0.3.0
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- redesign layout for wide page
- keep video index between refreshes
- show metadata as YAML
- include error logs sidebar
- fix checkbox state per video
- make video autoplay
- add PyYAML dependency

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68417530d39c83308ab0c4d37952763c