### PR TITLE
Fix layout and persist sorting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines for Codex Agents
+
+- Follow PEP8 when modifying Python code.
+- Before committing, run `python -m py_compile app.py` to ensure syntax is valid.
+- Include brief commit messages describing the change.


### PR DESCRIPTION
## Summary
- store sort settings in state
- capture keyboard with updated component API
- move labels and controls to a side column
- add repository guidelines

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68417e14ff908330b2f141a9057c0891