### PR TITLE
Fix missing folder in example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ video-labeler/
 ├── app.py            # Streamlit application
 ├── requirements.txt  # Dependencies
 ├── README.md         # This file
-└── videos/
+└── sample_videos/
     ├── <your .mp4 files>
     └── metadata.csv
 ```
@@ -66,7 +66,7 @@ pip install -r requirements.txt
 streamlit run app.py
 ```
 
-Open <http://localhost:8501> in your browser. The sidebar lets you select the video folder (default is `videos`).
+Open <http://localhost:8501> in your browser. The sidebar lets you select the video folder (default is `sample_videos`).
 
 ### Keyboard shortcuts
 

--- a/app.py
+++ b/app.py
@@ -23,6 +23,9 @@ LOG_PATH = "app.log"
 logging.basicConfig(filename=LOG_PATH, level=logging.INFO,
                     format="%(asctime)s [%(levelname)s] %(message)s")
 
+# Default directory that contains example videos and metadata.
+DEFAULT_DIR = "sample_videos"
+
 
 def log_exception(exc_type, exc_value, exc_tb):
     if issubclass(exc_type, KeyboardInterrupt):
@@ -36,7 +39,7 @@ sys.excepthook = log_exception
 STATE_PATH = "state.json"
 
 def load_state():
-    data = {"idx": 0, "video_dir": "videos", "sort_by": "filename", "order": "Ascending"}
+    data = {"idx": 0, "video_dir": DEFAULT_DIR, "sort_by": "filename", "order": "Ascending"}
     if os.path.exists(STATE_PATH):
         try:
             with open(STATE_PATH) as f:
@@ -63,7 +66,7 @@ def save_state():
 if any(k not in st.session_state for k in ("idx", "video_dir", "sort_by", "order")):
     saved = load_state()
     st.session_state.idx = saved.get("idx", 0)
-    st.session_state.video_dir = saved.get("video_dir", "videos")
+    st.session_state.video_dir = saved.get("video_dir", DEFAULT_DIR)
     st.session_state.sort_by = saved.get("sort_by", "filename")
     st.session_state.order = saved.get("order", "Ascending")
 
@@ -137,6 +140,8 @@ def prev_video():
     logging.info("Moved to previous video: %s", video_files[st.session_state.idx])
 
 # Capture keyboard
+# Some older Streamlit versions do not support the ``key`` argument for
+# ``components.html``. Avoid using it for compatibility.
 key = components.html(
     """
     <script>
@@ -148,7 +153,6 @@ key = components.html(
     </script>
     """,
     height=0,
-    key="nav",
 )
 
 if not isinstance(key, str):

--- a/sample_videos/metadata.csv
+++ b/sample_videos/metadata.csv
@@ -1,0 +1,3 @@
+filename,duration,source
+vid1.mp4,1.0,sample
+vid2.mp4,1.0,sample


### PR DESCRIPTION
## Summary
- default to `sample_videos` directory for easier testing
- update README accordingly

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_6841805db2ac83308b4dece4602ceec7